### PR TITLE
Guard threadsafe functions and deferreds against env teardown races

### DIFF
--- a/packages/edon/src/napi/js_values/deferred.rs
+++ b/packages/edon/src/napi/js_values/deferred.rs
@@ -1,6 +1,11 @@
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr;
+use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::Weak;
 
 use libnode_sys;
 
@@ -16,8 +21,18 @@ struct DeferredData<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> {
   resolver: Result<Resolver>,
 }
 
+/// Shared between the deferred and its env teardown hook / finalize callback: settles (or
+/// abort-releases) the underlying threadsafe function exactly once, under the `aborted` lock.
+struct DeferredHandle {
+  tsfn: AtomicPtr<libnode_sys::napi_threadsafe_function__>,
+  aborted: RwLock<bool>,
+}
+
+unsafe impl Send for DeferredHandle {}
+unsafe impl Sync for DeferredHandle {}
+
 pub struct JsDeferred<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> {
-  pub(crate) tsfn: libnode_sys::napi_threadsafe_function,
+  handle: Arc<DeferredHandle>,
   _data: PhantomData<Data>,
   _resolver: PhantomData<Resolver>,
 }
@@ -29,7 +44,7 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> Clone
 {
   fn clone(&self) -> Self {
     Self {
-      tsfn: self.tsfn,
+      handle: self.handle.clone(),
       _data: PhantomData,
       _resolver: PhantomData,
     }
@@ -43,10 +58,38 @@ unsafe impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> Send
 
 impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, Resolver> {
   pub(crate) fn new(env: libnode_sys::napi_env) -> Result<(Self, JsObject)> {
-    let (tsfn, promise) = js_deferred_new_raw(env, Some(napi_resolve_deferred::<Data, Resolver>))?;
+    let handle = Arc::new(DeferredHandle {
+      tsfn: AtomicPtr::new(ptr::null_mut()),
+      aborted: RwLock::new(false),
+    });
+    // Shared by the finalize callback and the env teardown hook; freed exactly once, by the
+    // finalize callback (which during an env teardown runs after the LIFO-ordered hooks).
+    let handle_weak_ptr = Box::into_raw(Box::new(Arc::downgrade(&handle)));
+
+    let (tsfn, promise) = js_deferred_new_raw(
+      env,
+      Some(napi_resolve_deferred::<Data, Resolver>),
+      handle_weak_ptr.cast(),
+    )
+    .inspect_err(|_| {
+      drop(unsafe { Box::from_raw(handle_weak_ptr) });
+    })?;
+    handle.tsfn.store(tsfn, Ordering::SeqCst);
+
+    // Pre-abort the threadsafe function when the environment tears down, before Node finalizes
+    // it: a deferred settled from a foreign thread after (or during) env teardown would
+    // otherwise call into a freed threadsafe function. See the same hook in
+    // threadsafe_function.rs for the ordering rationale.
+    check_status!(unsafe {
+      libnode_sys::napi_add_env_cleanup_hook(
+        env,
+        Some(deferred_env_teardown_cb),
+        handle_weak_ptr.cast(),
+      )
+    })?;
 
     let deferred = Self {
-      tsfn,
+      handle,
       _data: PhantomData,
       _resolver: PhantomData,
     };
@@ -75,12 +118,25 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, 
     self,
     result: Result<Resolver>,
   ) {
+    let mut aborted = self
+      .handle
+      .aborted
+      .write()
+      .expect("JsDeferred aborted lock failed");
+    if *aborted {
+      // The environment tore down (or the deferred already settled): the promise no longer
+      // exists and the threadsafe function is gone. Drop the resolver instead of calling into
+      // freed memory.
+      return;
+    }
+
+    let tsfn = self.handle.tsfn.load(Ordering::SeqCst);
     let data = DeferredData { resolver: result };
 
     // Call back into the JS thread via a threadsafe function. This results in napi_resolve_deferred being called.
     let status = unsafe {
       libnode_sys::napi_call_threadsafe_function(
-        self.tsfn,
+        tsfn,
         Box::into_raw(Box::from(data)).cast(),
         libnode_sys::ThreadsafeFunctionCallMode::blocking,
       )
@@ -92,7 +148,7 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, 
 
     let status = unsafe {
       libnode_sys::napi_release_threadsafe_function(
-        self.tsfn,
+        tsfn,
         libnode_sys::ThreadsafeFunctionReleaseMode::release,
       )
     };
@@ -100,12 +156,66 @@ impl<Data: ToNapiValue, Resolver: FnOnce(Env) -> Result<Data>> JsDeferred<Data, 
       status == libnode_sys::Status::napi_ok,
       "Release threadsafe function in JsDeferred failed"
     );
+
+    *aborted = true;
+  }
+}
+
+/// Aborts the deferred's threadsafe function when its environment starts tearing down, before
+/// Node finalizes it. Runs on the environment's thread; the `aborted` write lock serializes it
+/// against settles on foreign threads.
+unsafe extern "C" fn deferred_env_teardown_cb(data: *mut c_void) {
+  let handle_weak = unsafe { &*data.cast::<Weak<DeferredHandle>>() };
+  let Some(handle) = handle_weak.upgrade() else {
+    return;
+  };
+
+  let mut aborted = handle
+    .aborted
+    .write()
+    .expect("JsDeferred aborted lock failed");
+  if !*aborted {
+    let status = unsafe {
+      libnode_sys::napi_release_threadsafe_function(
+        handle.tsfn.load(Ordering::SeqCst),
+        libnode_sys::ThreadsafeFunctionReleaseMode::abort,
+      )
+    };
+    debug_assert!(
+      status == libnode_sys::Status::napi_ok,
+      "Abort deferred threadsafe function on env teardown failed"
+    );
+    *aborted = true;
+  }
+}
+
+/// Finalize callback of the deferred's threadsafe function: unregisters the teardown hook and
+/// frees the shared handle weak exactly once.
+unsafe extern "C" fn deferred_finalize_cb(
+  env: libnode_sys::napi_env,
+  finalize_data: *mut c_void,
+  _finalize_hint: *mut c_void,
+) {
+  if !env.is_null() {
+    unsafe {
+      libnode_sys::napi_remove_env_cleanup_hook(env, Some(deferred_env_teardown_cb), finalize_data)
+    };
+  }
+
+  let handle_weak = unsafe { Box::from_raw(finalize_data.cast::<Weak<DeferredHandle>>()) };
+  if let Some(handle) = handle_weak.upgrade() {
+    let mut aborted = handle
+      .aborted
+      .write()
+      .expect("JsDeferred aborted lock failed");
+    *aborted = true;
   }
 }
 
 fn js_deferred_new_raw(
   env: libnode_sys::napi_env,
   resolve_deferred: libnode_sys::napi_threadsafe_function_call_js,
+  finalize_data: *mut c_void,
 ) -> Result<(libnode_sys::napi_threadsafe_function, JsObject)> {
   let mut raw_promise = ptr::null_mut();
   let mut raw_deferred = ptr::null_mut();
@@ -137,8 +247,8 @@ fn js_deferred_new_raw(
         async_resource_name,
         0,
         1,
-        ptr::null_mut(),
-        None,
+        finalize_data,
+        Some(deferred_finalize_cb),
         raw_deferred.cast(),
         resolve_deferred,
         &mut tsfn,
@@ -162,8 +272,15 @@ extern "C" fn napi_resolve_deferred<Data: ToNapiValue, Resolver: FnOnce(Env) -> 
   context: *mut c_void,
   data: *mut c_void,
 ) {
-  let deferred = context.cast();
   let deferred_data: Box<DeferredData<Data, Resolver>> = unsafe { Box::from_raw(data.cast()) };
+
+  // Node invokes leftover queue items with a null env while the threadsafe function closes
+  // during env teardown; there is no promise left to settle.
+  if env.is_null() {
+    return;
+  }
+
+  let deferred = context.cast();
   let result = deferred_data
     .resolver
     .and_then(|resolver| resolver(unsafe { Env::from_raw(env) }))

--- a/packages/edon/src/napi/threadsafe_function.rs
+++ b/packages/edon/src/napi/threadsafe_function.rs
@@ -639,7 +639,8 @@ unsafe extern "C" fn thread_finalize_cb<T: 'static, V: ToNapiValue, R>(
     unsafe { libnode_sys::napi_remove_env_cleanup_hook(env, Some(env_teardown_cb), finalize_data) };
   }
 
-  let handle_weak = unsafe { Box::from_raw(finalize_data.cast::<Weak<ThreadsafeFunctionHandle>>()) };
+  let handle_weak =
+    unsafe { Box::from_raw(finalize_data.cast::<Weak<ThreadsafeFunctionHandle>>()) };
 
   if let Some(handle) = handle_weak.upgrade() {
     handle.with_write_aborted(|mut aborted_guard| {

--- a/packages/edon/src/napi/threadsafe_function.rs
+++ b/packages/edon/src/napi/threadsafe_function.rs
@@ -372,6 +372,10 @@ impl<T: 'static, ES: ErrorStrategy::T> ThreadsafeFunction<T, ES> {
     let mut raw_tsfn = ptr::null_mut();
     let callback_ptr = Box::into_raw(Box::new(callback));
     let handle = ThreadsafeFunctionHandle::null();
+    // Shared by thread_finalize_cb and env_teardown_cb; freed exactly once, by
+    // thread_finalize_cb (which napi guarantees to call exactly once, and which during an env
+    // teardown runs after the LIFO-ordered cleanup hooks).
+    let handle_weak_ptr = Box::into_raw(Box::new(Arc::downgrade(&handle)));
     check_status!(unsafe {
       libnode_sys::napi_create_threadsafe_function(
         env,
@@ -380,14 +384,27 @@ impl<T: 'static, ES: ErrorStrategy::T> ThreadsafeFunction<T, ES> {
         async_resource_name,
         max_queue_size,
         1,
-        Arc::downgrade(&handle).into_raw() as *mut c_void, // pass handler to thread_finalize_cb
+        handle_weak_ptr.cast(), // pass handler to thread_finalize_cb
         Some(thread_finalize_cb::<T, V, R>),
         callback_ptr.cast(),
         Some(call_js_cb::<T, V, R, ES>),
         &mut raw_tsfn,
       )
+    })
+    .inspect_err(|_| {
+      drop(unsafe { Box::from_raw(handle_weak_ptr) });
     })?;
     handle.set_raw(raw_tsfn);
+
+    // Pre-abort the threadsafe function when its environment tears down. Node registers the
+    // threadsafe function's own teardown as an env cleanup hook at creation; hooks run in
+    // reverse registration order, so this hook (registered after) runs first and aborts the
+    // threadsafe function under the `aborted` lock *before* Node finalizes it. Without it, a
+    // handle dropped from a foreign thread while the environment is mid-teardown races Node's
+    // finalization of the same threadsafe function and corrupts the heap.
+    check_status!(unsafe {
+      libnode_sys::napi_add_env_cleanup_hook(env, Some(env_teardown_cb), handle_weak_ptr.cast())
+    })?;
 
     Ok(ThreadsafeFunction {
       handle,
@@ -578,6 +595,35 @@ impl<T: 'static> ThreadsafeFunction<T, ErrorStrategy::Fatal> {
   }
 }
 
+/// Aborts the threadsafe function when its environment starts tearing down, before Node
+/// finalizes it. Runs on the environment's thread; the `aborted` write lock serializes it
+/// against handle drops and calls on foreign threads, so after this hook ran (or while it
+/// runs) no foreign thread can touch the dying threadsafe function anymore.
+unsafe extern "C" fn env_teardown_cb(data: *mut c_void) {
+  let handle_weak = unsafe { &*data.cast::<Weak<ThreadsafeFunctionHandle>>() };
+  let Some(handle) = handle_weak.upgrade() else {
+    // The last handle was already dropped (and released the threadsafe function itself).
+    return;
+  };
+
+  handle.with_write_aborted(|mut aborted_guard| {
+    if !*aborted_guard {
+      let release_status = unsafe {
+        libnode_sys::napi_release_threadsafe_function(
+          handle.get_raw(),
+          libnode_sys::ThreadsafeFunctionReleaseMode::abort,
+        )
+      };
+      debug_assert!(
+        release_status == libnode_sys::Status::napi_ok,
+        "Abort threadsafe function on env teardown failed {}",
+        Status::from(release_status)
+      );
+      *aborted_guard = true;
+    }
+  });
+}
+
 #[allow(unused_variables)]
 unsafe extern "C" fn thread_finalize_cb<T: 'static, V: ToNapiValue, R>(
   env: libnode_sys::napi_env,
@@ -586,10 +632,16 @@ unsafe extern "C" fn thread_finalize_cb<T: 'static, V: ToNapiValue, R>(
 ) where
   R: 'static + Send + FnMut(ThreadSafeCallContext<T>) -> Result<Vec<V>>,
 {
-  let handle_option =
-    unsafe { Weak::from_raw(finalize_data.cast::<ThreadsafeFunctionHandle>()).upgrade() };
+  // The teardown hook must be unregistered before its data is freed below. If it already ran
+  // (env teardown finalized this threadsafe function), Node has dequeued it and the removal is
+  // a harmless no-op error.
+  if !env.is_null() {
+    unsafe { libnode_sys::napi_remove_env_cleanup_hook(env, Some(env_teardown_cb), finalize_data) };
+  }
 
-  if let Some(handle) = handle_option {
+  let handle_weak = unsafe { Box::from_raw(finalize_data.cast::<Weak<ThreadsafeFunctionHandle>>()) };
+
+  if let Some(handle) = handle_weak.upgrade() {
     handle.with_write_aborted(|mut aborted_guard| {
       if !*aborted_guard {
         *aborted_guard = true;

--- a/packages/edon/src/nodejs.rs
+++ b/packages/edon/src/nodejs.rs
@@ -215,7 +215,7 @@ impl Nodejs {
         callback: Box::new(callback),
       })
       .unwrap();
-    
+
     Ok(())
   }
 

--- a/packages/edon/src/nodejs_worker.rs
+++ b/packages/edon/src/nodejs_worker.rs
@@ -41,7 +41,7 @@ impl NodejsWorker {
     });
   }
 
-    pub fn eval<Code: AsRef<str>>(
+  pub fn eval<Code: AsRef<str>>(
     &self,
     code: Code,
     callback: impl 'static + Send + FnOnce(Env, JsUnknown),
@@ -154,7 +154,7 @@ impl NodejsWorker {
         callback: Box::new(callback),
       })
       .unwrap();
-    
+
     Ok(())
   }
 


### PR DESCRIPTION
## Problem

Both TSFN owners in edon race Node's own threadsafe-function finalization when a worker environment tears down. Unlike a typical addon — where the only env teardown is process exit — edon's worker environments are restartable, so this window opens on every worker shutdown and manifests as heap corruption (crashes inside `Isolate::Deinit`, allocator faults in finalize callbacks).

1. **`ThreadsafeFunction`**: the `aborted` flag is only set from the napi finalize callback, which runs *during* teardown. A handle dropped from a foreign thread in that window passes the `!aborted` check and calls `napi_release_threadsafe_function` on a threadsafe function Node is concurrently closing. (Upstream napi-rs has the same latent model in its public TSFN; it rarely fires there because addons live in the main env.)

2. **`JsDeferred`**: a raw `napi_threadsafe_function` with no finalize callback and no teardown awareness. A deferred settled from a foreign thread after env teardown calls straight into freed memory. It also double-released when both clones of the panic-handler trick settled, and `napi_resolve_deferred` dereferenced the null env Node passes for leftover queue items during teardown.

## Fix

Follow the guard pattern upstream napi-rs uses for its internal custom-GC TSFN (`custom_gc_finalize` + `THREADS_CAN_ACCESS_ENV`): register an env cleanup hook at creation time. Node registers the TSFN's own teardown as a cleanup hook when the TSFN is created, and hooks run in reverse registration order, so ours runs first — it abort-releases the TSFN under the `aborted` write lock *before* Node finalizes it. Every later drop/call/settle observes the flag and becomes a no-op.

The hook data shares one `Box<Weak<handle>>` with the finalize callback, which unregisters the hook and frees it exactly once (finalize runs after the LIFO hooks during teardown, and removing an already-executed hook is a harmless no-op).

Compile-checked with the pinned 1.86.0 toolchain.
