### PR TITLE
Port Promise<T> and ThreadsafeFunction::call_async from napi-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -242,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +325,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/packages/edon/Cargo.toml
+++ b/packages/edon/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 serde-json = ["serde", "serde_json"]
 error-anyhow = ["anyhow"]
 chrono-date = ["chrono"]
+tokio_rt = ["tokio"]
 
 [lib]
 
@@ -25,3 +26,4 @@ anyhow = { version = "^1", optional = true }
 serde = { version = "^1", optional = true }
 serde_json = { version = "^1", optional = true }
 chrono = { version = "^0.4", optional = true }
+tokio = { version = "^1", default-features = false, features = ["sync"], optional = true }

--- a/packages/edon/src/napi/bindgen_runtime/js_values.rs
+++ b/packages/edon/src/napi/bindgen_runtime/js_values.rs
@@ -29,6 +29,8 @@ mod map;
 mod nil;
 mod number;
 mod object;
+#[cfg(feature = "tokio_rt")]
+mod promise;
 #[cfg(feature = "serde-json")]
 mod serde;
 mod string;
@@ -46,6 +48,8 @@ pub use external::*;
 pub use function::*;
 pub use nil::*;
 pub use object::*;
+#[cfg(feature = "tokio_rt")]
+pub use promise::*;
 pub use string::*;
 pub use symbol::*;
 pub use task::*;

--- a/packages/edon/src/napi/bindgen_runtime/js_values/promise.rs
+++ b/packages/edon/src/napi/bindgen_runtime/js_values/promise.rs
@@ -1,0 +1,285 @@
+// Ported from napi-rs (napi@2.16.17) crates/napi/src/bindgen_runtime/js_values/promise.rs,
+// adapted to edon's vendored napi subset.
+
+use std::ffi::CStr;
+use std::future;
+use std::pin::Pin;
+use std::ptr;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use libnode_sys;
+use tokio::sync::oneshot::channel;
+use tokio::sync::oneshot::Receiver;
+use tokio::sync::oneshot::Sender;
+
+use super::FromNapiValue;
+use super::TypeName;
+use super::ValidateNapiValue;
+use crate::napi::check_status;
+use crate::napi::Error;
+use crate::napi::JsUnknown;
+use crate::napi::NapiValue;
+use crate::napi::Result;
+use crate::napi::Status;
+
+/// A JavaScript `Promise` captured on the JS thread as a Rust `Future`.
+///
+/// `from_napi_value` attaches native `then`/`catch` handlers to the promise on the JS thread;
+/// awaiting the resulting value resolves when the promise settles. Combined with
+/// [`ThreadsafeFunction::call_async`](crate::napi::threadsafe_function::ThreadsafeFunction),
+/// this allows awaiting an async JS function end-to-end:
+/// `tsfn.call_async::<Promise<Data>>(args).await?.await?`.
+pub struct Promise<T: FromNapiValue> {
+  value: Pin<Box<Receiver<*mut Result<T>>>>,
+  aborted: Arc<AtomicBool>,
+}
+
+impl<T: FromNapiValue> Drop for Promise<T> {
+  fn drop(&mut self) {
+    self.aborted.store(true, Ordering::SeqCst);
+  }
+}
+
+impl<T: FromNapiValue> TypeName for Promise<T> {
+  fn type_name() -> &'static str {
+    "Promise"
+  }
+
+  fn value_type() -> crate::napi::ValueType {
+    crate::napi::ValueType::Object
+  }
+}
+
+impl<T: FromNapiValue> ValidateNapiValue for Promise<T> {
+  unsafe fn validate(
+    env: libnode_sys::napi_env,
+    napi_val: libnode_sys::napi_value,
+  ) -> Result<libnode_sys::napi_value> {
+    let mut is_promise = false;
+    check_status!(
+      unsafe { libnode_sys::napi_is_promise(env, napi_val, &mut is_promise) },
+      "Failed to check if value is promise"
+    )?;
+    if !is_promise {
+      let mut deferred = ptr::null_mut();
+      let mut promise = ptr::null_mut();
+      check_status!(
+        unsafe { libnode_sys::napi_create_promise(env, &mut deferred, &mut promise) },
+        "Failed to create promise"
+      )?;
+      let mut err = ptr::null_mut();
+      let mut code = ptr::null_mut();
+      let mut message = ptr::null_mut();
+      check_status!(
+        unsafe {
+          libnode_sys::napi_create_string_utf8(env, "InvalidArg\0".as_ptr().cast(), 10, &mut code)
+        },
+        "Failed to create error message"
+      )?;
+      check_status!(
+        unsafe {
+          libnode_sys::napi_create_string_utf8(
+            env,
+            "Expected Promise object\0".as_ptr().cast(),
+            23,
+            &mut message,
+          )
+        },
+        "Failed to create error message"
+      )?;
+      check_status!(
+        unsafe { libnode_sys::napi_create_error(env, code, message, &mut err) },
+        "Failed to create rejected error"
+      )?;
+      check_status!(
+        unsafe { libnode_sys::napi_reject_deferred(env, deferred, err) },
+        "Failed to reject promise in validate"
+      )?;
+      return Ok(promise);
+    }
+    Ok(ptr::null_mut())
+  }
+}
+
+unsafe impl<T: FromNapiValue + Send> Send for Promise<T> {}
+
+impl<T: FromNapiValue> FromNapiValue for Promise<T> {
+  unsafe fn from_napi_value(
+    env: libnode_sys::napi_env,
+    napi_val: libnode_sys::napi_value,
+  ) -> Result<Self> {
+    let mut then = ptr::null_mut();
+    let then_c_string = unsafe { CStr::from_bytes_with_nul_unchecked(b"then\0") };
+    check_status!(
+      unsafe {
+        libnode_sys::napi_get_named_property(env, napi_val, then_c_string.as_ptr(), &mut then)
+      },
+      "Failed to get then function"
+    )?;
+    let mut promise_after_then = ptr::null_mut();
+    let mut then_js_cb = ptr::null_mut();
+    let (tx, rx) = channel();
+    let aborted = Arc::new(AtomicBool::new(false));
+    let tx_ptr = Box::into_raw(Box::new((tx, aborted.clone())));
+    check_status!(
+      unsafe {
+        libnode_sys::napi_create_function(
+          env,
+          then_c_string.as_ptr(),
+          4,
+          Some(then_callback::<T>),
+          tx_ptr.cast(),
+          &mut then_js_cb,
+        )
+      },
+      "Failed to create then callback"
+    )?;
+    check_status!(
+      unsafe {
+        libnode_sys::napi_call_function(
+          env,
+          napi_val,
+          then,
+          1,
+          [then_js_cb].as_ptr(),
+          &mut promise_after_then,
+        )
+      },
+      "Failed to call then method"
+    )?;
+    let mut catch = ptr::null_mut();
+    let catch_c_string = unsafe { CStr::from_bytes_with_nul_unchecked(b"catch\0") };
+    check_status!(
+      unsafe {
+        libnode_sys::napi_get_named_property(
+          env,
+          promise_after_then,
+          catch_c_string.as_ptr(),
+          &mut catch,
+        )
+      },
+      "Failed to get catch function"
+    )?;
+    let mut catch_js_cb = ptr::null_mut();
+    check_status!(
+      unsafe {
+        libnode_sys::napi_create_function(
+          env,
+          catch_c_string.as_ptr(),
+          5,
+          Some(catch_callback::<T>),
+          tx_ptr.cast(),
+          &mut catch_js_cb,
+        )
+      },
+      "Failed to create catch callback"
+    )?;
+    check_status!(
+      unsafe {
+        libnode_sys::napi_call_function(
+          env,
+          promise_after_then,
+          catch,
+          1,
+          [catch_js_cb].as_ptr(),
+          ptr::null_mut(),
+        )
+      },
+      "Failed to call catch method"
+    )?;
+    Ok(Promise {
+      value: Box::pin(rx),
+      aborted,
+    })
+  }
+}
+
+impl<T: FromNapiValue> future::Future for Promise<T> {
+  type Output = Result<T>;
+
+  fn poll(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Self::Output> {
+    match self.value.as_mut().poll(cx) {
+      Poll::Pending => Poll::Pending,
+      Poll::Ready(v) => Poll::Ready(
+        v.map_err(|e| Error::new(Status::GenericFailure, format!("{}", e)))
+          .and_then(|v| unsafe { *Box::from_raw(v) }),
+      ),
+    }
+  }
+}
+
+unsafe extern "C" fn then_callback<T: FromNapiValue>(
+  env: libnode_sys::napi_env,
+  info: libnode_sys::napi_callback_info,
+) -> libnode_sys::napi_value {
+  let mut data = ptr::null_mut();
+  let mut resolved_value: [libnode_sys::napi_value; 1] = [ptr::null_mut()];
+  let mut this = ptr::null_mut();
+  let get_cb_status = unsafe {
+    libnode_sys::napi_get_cb_info(
+      env,
+      info,
+      &mut 1,
+      resolved_value.as_mut_ptr(),
+      &mut this,
+      &mut data,
+    )
+  };
+  debug_assert!(
+    get_cb_status == libnode_sys::Status::napi_ok,
+    "Get callback info from Promise::then failed"
+  );
+  let (sender, aborted) =
+    *unsafe { Box::from_raw(data as *mut (Sender<*mut Result<T>>, Arc<AtomicBool>)) };
+  if aborted.load(Ordering::SeqCst) {
+    return this;
+  }
+  let resolve_value_t = Box::new(unsafe { T::from_napi_value(env, resolved_value[0]) });
+  // The only reason for send to return Err is if the receiver isn't listening
+  // Not hiding the error would result in a panic, it's safe to ignore it instead.
+  let _ = sender.send(Box::into_raw(resolve_value_t));
+  this
+}
+
+unsafe extern "C" fn catch_callback<T: FromNapiValue>(
+  env: libnode_sys::napi_env,
+  info: libnode_sys::napi_callback_info,
+) -> libnode_sys::napi_value {
+  let mut data = ptr::null_mut();
+  let mut rejected_value: [libnode_sys::napi_value; 1] = [ptr::null_mut()];
+  let mut this = ptr::null_mut();
+  let mut argc = 1;
+  let get_cb_status = unsafe {
+    libnode_sys::napi_get_cb_info(
+      env,
+      info,
+      &mut argc,
+      rejected_value.as_mut_ptr(),
+      &mut this,
+      &mut data,
+    )
+  };
+  debug_assert!(
+    get_cb_status == libnode_sys::Status::napi_ok,
+    "Get callback info from Promise::catch failed"
+  );
+  let rejected_value = rejected_value[0];
+  let (sender, aborted) =
+    *unsafe { Box::from_raw(data as *mut (Sender<*mut Result<T>>, Arc<AtomicBool>)) };
+  if aborted.load(Ordering::SeqCst) {
+    return this;
+  }
+  // The only reason for send to return Err is if the receiver isn't listening
+  // Not hiding the error would result in a panic, it's safe to ignore it instead.
+  let _ = sender.send(Box::into_raw(Box::new(Err(Error::from(unsafe {
+    JsUnknown::from_raw_unchecked(env, rejected_value)
+  })))));
+  this
+}

--- a/packages/edon/src/napi/threadsafe_function.rs
+++ b/packages/edon/src/napi/threadsafe_function.rs
@@ -517,6 +517,58 @@ impl<T: 'static> ThreadsafeFunction<T, ErrorStrategy::CalleeHandled> {
       .into()
     })
   }
+
+  /// Calls the threadsafe function and awaits the JS callback's return value. Ported from
+  /// napi-rs's `ThreadsafeFunction::call_async`; combine with
+  /// [`Promise<D>`](crate::napi::bindgen_runtime::Promise) as the return type to await an
+  /// async JS function end-to-end.
+  #[cfg(feature = "tokio_rt")]
+  pub async fn call_async<D: 'static + FromNapiValue>(
+    &self,
+    value: Result<T>,
+  ) -> Result<D> {
+    let (sender, receiver) = tokio::sync::oneshot::channel::<Result<D>>();
+
+    self.handle.with_read_aborted(|aborted| {
+      if aborted {
+        return Err(crate::napi::Error::from_status(Status::Closing));
+      }
+
+      check_status!(
+        unsafe {
+          libnode_sys::napi_call_threadsafe_function(
+            self.handle.get_raw(),
+            Box::into_raw(Box::new(value.map(|data| {
+              ThreadsafeFunctionCallJsBackData {
+                data,
+                call_variant: ThreadsafeFunctionCallVariant::WithCallback,
+                callback: Box::new(move |d: Result<JsUnknown>| {
+                  sender
+                    .send(d.and_then(|d| D::from_napi_value(d.0.env, d.0.value)))
+                    // The only reason for send to return Err is if the receiver isn't listening
+                    // Not hiding the error would result in a napi_fatal_error call, it's safe to ignore it instead.
+                    .or(Ok(()))
+                }),
+              }
+            })))
+            .cast(),
+            libnode_sys::ThreadsafeFunctionCallMode::nonblocking,
+          )
+        },
+        "Threadsafe function call_async failed"
+      )
+    })?;
+
+    receiver
+      .await
+      .map_err(|_| {
+        crate::napi::Error::new(
+          Status::GenericFailure,
+          "Receive value from threadsafe function sender failed",
+        )
+      })
+      .and_then(|ret| ret)
+  }
 }
 
 impl<T: 'static> ThreadsafeFunction<T, ErrorStrategy::Fatal> {
@@ -575,6 +627,54 @@ impl<T: 'static> ThreadsafeFunction<T, ErrorStrategy::Fatal> {
       }
       .into()
     })
+  }
+
+  /// Calls the threadsafe function and awaits the JS callback's return value. Ported from
+  /// napi-rs's `ThreadsafeFunction::call_async`; combine with
+  /// [`Promise<D>`](crate::napi::bindgen_runtime::Promise) as the return type to await an
+  /// async JS function end-to-end.
+  #[cfg(feature = "tokio_rt")]
+  pub async fn call_async<D: 'static + FromNapiValue>(
+    &self,
+    value: T,
+  ) -> Result<D> {
+    let (sender, receiver) = tokio::sync::oneshot::channel::<D>();
+
+    self.handle.with_read_aborted(|aborted| {
+      if aborted {
+        return Err(crate::napi::Error::from_status(Status::Closing));
+      }
+
+      check_status!(
+        unsafe {
+          libnode_sys::napi_call_threadsafe_function(
+            self.handle.get_raw(),
+            Box::into_raw(Box::new(ThreadsafeFunctionCallJsBackData {
+              data: value,
+              call_variant: ThreadsafeFunctionCallVariant::WithCallback,
+              callback: Box::new(move |d: Result<JsUnknown>| {
+                d.and_then(|d| {
+                  D::from_napi_value(d.0.env, d.0.value).and_then(move |d| {
+                    sender
+                      .send(d)
+                      // The only reason for send to return Err is if the receiver isn't listening
+                      // Not hiding the error would result in a napi_fatal_error call, it's safe to ignore it instead.
+                      .or(Ok(()))
+                  })
+                })
+              }),
+            }))
+            .cast(),
+            libnode_sys::ThreadsafeFunctionCallMode::nonblocking,
+          )
+        },
+        "Threadsafe function call_async failed"
+      )
+    })?;
+
+    receiver
+      .await
+      .map_err(|err| crate::napi::Error::new(Status::GenericFailure, format!("{}", err)))
   }
 }
 

--- a/packages/edon/src/nodejs.rs
+++ b/packages/edon/src/nodejs.rs
@@ -215,7 +215,7 @@ impl Nodejs {
         callback: Box::new(callback),
       })
       .unwrap();
-    
+
     Ok(())
   }
 

--- a/packages/edon/src/nodejs_worker.rs
+++ b/packages/edon/src/nodejs_worker.rs
@@ -41,7 +41,7 @@ impl NodejsWorker {
     });
   }
 
-    pub fn eval<Code: AsRef<str>>(
+  pub fn eval<Code: AsRef<str>>(
     &self,
     code: Code,
     callback: impl 'static + Send + FnOnce(Env, JsUnknown),
@@ -154,7 +154,7 @@ impl NodejsWorker {
         callback: Box::new(callback),
       })
       .unwrap();
-    
+
     Ok(())
   }
 


### PR DESCRIPTION
## What

Ports two pieces from upstream napi-rs (`napi@2.16.17`, the generation this napi subset was vendored from) that edon was missing:

- **`Promise<T>`** (`bindgen_runtime/js_values/promise.rs`): a `FromNapiValue` that attaches native `then`/`catch` handlers to a JS promise on the JS thread and implements `Future`, resolving with `Result<T>` when the promise settles. Includes upstream's `ValidateNapiValue` impl (rejects non-promise values) and the aborted-flag guard that makes settlement after the Rust side dropped the future a no-op.
- **`ThreadsafeFunction::call_async<D>`** on both error strategies: calls the threadsafe function and awaits the JS callback's return value through a oneshot channel, using the `ThreadsafeFunctionCallVariant::WithCallback` plumbing that already exists in this crate.

Combined, they let embedders await an async JS function end-to-end:

```rust
let response: Data = tsfn.call_async::<Promise<Data>>(args).await?.await?;
```

## Why

Without these, embedders calling an async JS handler have to hand-roll the equivalent: `call_with_return_value`, grab the returned promise's `then` on the JS thread, attach native settlers, and feed a oneshot manually. That per-embedder boilerplate is easy to get subtly wrong; upstream napi-rs solved it once and this port reuses that implementation.

## Notes

- Gated behind a new `tokio_rt` feature (same name as upstream's), which adds an optional `tokio` dependency restricted to the `sync` feature. Default build is unaffected.
- The only deviations from the upstream source are mechanical: `sys` → `libnode_sys`, crate paths, and this crate's import/formatting style.
- Compile-checked with the pinned 1.86.0 toolchain, with and without the feature.